### PR TITLE
basic client functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name = "varlink",
     packages = ["varlink"],
-    version = "1",
+    version = "2",
     description = "Varlink",
     author = "Lars Karlitski",
     author_email = "lars@karlitski.net",


### PR DESCRIPTION
This patch adds basic client functionality.
It generates interfaces and methods dynamically via varlink inspection.
```
$ python3 example.py
{'account': {'name': 'root', 'uid': 0, 'gid': 0, 'full_name': 'root', 'home': '/root', 'shell': '/bin/bash'}}
```
```
$ cat example.py
from varlink import Client

if __name__ == '__main__':
    resolver = Client("unix:/run/org.varlink.resolver")
    ret = resolver['org.varlink.resolver'].Resolve('com.redhat.system.accounts')

    accounts = Client(ret['address'])['com.redhat.system.accounts']
    ret = accounts.GetAccountByName("root")
    print(ret)
```